### PR TITLE
Enable TCP_NODELAY for better performance

### DIFF
--- a/lib/src/buffered_socket.dart
+++ b/lib/src/buffered_socket.dart
@@ -38,9 +38,11 @@ class BufferedSocket {
   StreamSubscription _subscription;
   bool _closed = false;
 
-  BufferedSocket._(this._socket, this.onDataReady, this.onDone, this.onError, this.onClosed)
+  BufferedSocket._(
+      this._socket, this.onDataReady, this.onDone, this.onError, this.onClosed)
       : log = new Logger("BufferedSocket") {
-    _subscription = _socket.listen(_onData, onError: _onSocketError, onDone: _onSocketDone, cancelOnError: true);
+    _subscription = _socket.listen(_onData,
+        onError: _onSocketError, onDone: _onSocketDone, cancelOnError: true);
   }
 
   _onSocketError(error) {
@@ -68,7 +70,9 @@ class BufferedSocket {
     try {
       var socket;
       socket = await socketFactory(host, port);
-      var bufferedSocket = new BufferedSocket._(socket, onDataReady, onDone, onError, onClosed);
+      socket.setOption(SocketOption.TCP_NODELAY, true);
+      var bufferedSocket =
+          new BufferedSocket._(socket, onDataReady, onDone, onError, onClosed);
       if (onConnection != null) {
         onConnection(bufferedSocket);
       }
@@ -132,7 +136,8 @@ class BufferedSocket {
 
   void _writeBuffer() {
     log.fine("_writeBuffer offset=${_writeOffset}");
-    int bytesWritten = _writingBuffer.writeToSocket(_socket, _writeOffset, _writeLength - _writeOffset);
+    int bytesWritten = _writingBuffer.writeToSocket(
+        _socket, _writeOffset, _writeLength - _writeOffset);
     log.fine("Wrote $bytesWritten bytes");
     if (log.isLoggable(Level.FINE)) {
       log.fine("\n${Buffer.debugChars(_writingBuffer.list)}");
@@ -149,7 +154,7 @@ class BufferedSocket {
   /**
    * Reads into [buffer] from the socket, and returns the same buffer in a [Future] which
    * completes when enough bytes have been read to fill the buffer.
-   *  
+   *
    * This must not be called while there is still a read ongoing, but may be called before
    * onDataReady is called, in which case onDataReady will not be called when data arrives,
    * and the read will start instead.
@@ -175,7 +180,8 @@ class BufferedSocket {
   }
 
   void _readBuffer() {
-    int bytesRead = _readingBuffer.readFromSocket(_socket, _readingBuffer.length - _readOffset);
+    int bytesRead = _readingBuffer.readFromSocket(
+        _socket, _readingBuffer.length - _readOffset);
     log.fine("read $bytesRead bytes");
     if (log.isLoggable(Level.FINE)) {
       log.fine("\n${Buffer.debugChars(_readingBuffer.list)}");
@@ -194,10 +200,12 @@ class BufferedSocket {
 
   Future startSSL() async {
     log.fine("Securing socket");
-    var socket = await RawSecureSocket.secure(_socket, subscription: _subscription, onBadCertificate: (cert) => true);
+    var socket = await RawSecureSocket.secure(_socket,
+        subscription: _subscription, onBadCertificate: (cert) => true);
     log.fine("Socket is secure");
     _socket = socket;
-    _subscription = _socket.listen(_onData, onError: _onSocketError, onDone: _onSocketDone, cancelOnError: true);
+    _subscription = _socket.listen(_onData,
+        onError: _onSocketError, onDone: _onSocketDone, cancelOnError: true);
     _socket.writeEventsEnabled = true;
     _socket.readEventsEnabled = true;
   }

--- a/lib/src/connection_pool.dart
+++ b/lib/src/connection_pool.dart
@@ -5,7 +5,9 @@ part of sqljocky;
  * a free connection it will be used, otherwise the query is queued until a connection is
  * free.
  */
-class ConnectionPool extends Object with _ConnectionHelpers implements QueriableConnection {
+class ConnectionPool extends Object
+    with _ConnectionHelpers
+    implements QueriableConnection {
   final Logger _log;
 
   final String _host;
@@ -70,11 +72,13 @@ class ConnectionPool extends Object with _ConnectionHelpers implements Queriable
     var c = new Completer<_Connection>();
 
     if (_log.isLoggable(Level.FINEST)) {
-      var inUseCount = _pool.fold(0, (value, cnx) => cnx.inUse ? value + 1 : value);
+      var inUseCount =
+          _pool.fold(0, (value, cnx) => cnx.inUse ? value + 1 : value);
       _log.finest("Number of in-use connections: $inUseCount");
     }
 
-    var cnx = _pool.firstWhere((aConnection) => !aConnection.inUse, orElse: () => null);
+    var cnx = _pool.firstWhere((aConnection) => !aConnection.inUse,
+        orElse: () => null);
     if (cnx != null) {
       _log.finest("Using open pooled cnx#${cnx.number}");
       cnx.use();
@@ -121,10 +125,10 @@ class ConnectionPool extends Object with _ConnectionHelpers implements Queriable
   /**
    * Attempts to continue using a connection. If the connection isn't managed
    * by this pool, or if the connection is already in use, nothing happens.
-   * 
+   *
    * If there are operations which have been queued in this pool, starts
-   * to execute that operation. 
-   * 
+   * to execute that operation.
+   *
    * Otherwise, nothing happens.
    */
   _reuseConnectionForQueuedOperations(_Connection cnx) {
@@ -138,7 +142,8 @@ class ConnectionPool extends Object with _ConnectionHelpers implements Queriable
       return;
     }
 
-    if (_requestedConnections.containsKey(cnx) && _requestedConnections[cnx].length > 0) {
+    if (_requestedConnections.containsKey(cnx) &&
+        _requestedConnections[cnx].length > 0) {
       _log.finest("Reusing cnx#${cnx.number} for a requested operation");
       var c = _requestedConnections[cnx].removeFirst();
       cnx.use();
@@ -251,7 +256,8 @@ class ConnectionPool extends Object with _ConnectionHelpers implements Queriable
         _log.finest("Connection not ready");
         await _waitUntilReady(cnx);
         _log.finest("Connection ready - closing query: ${q.sql}");
-        var handler = new _CloseStatementHandler(preparedQuery.statementHandlerId);
+        var handler =
+            new _CloseStatementHandler(preparedQuery.statementHandlerId);
         cnx.autoRelease = !retain;
         cnx.processHandler(handler, noResponse: true);
       }
@@ -318,14 +324,14 @@ class ConnectionPool extends Object with _ConnectionHelpers implements Queriable
 
 /**
    * Gets a persistent connection to the database.
-   * 
+   *
    * When you execute a query on the connection pool, it waits until a free
    * connection is available, executes the query and then returns the connection
    * back to the connection pool. Sometimes there may be cases where you want
    * to keep the same connection around for subsequent queries (such as when
    * you lock tables). Use this method to get a connection which isn't released
    * after each query.
-   * 
+   *
    * You must use [RetainedConnection.release] when you have finished with the
    * connection, otherwise it will not be available in the pool again.
    */
@@ -370,7 +376,7 @@ abstract class _ConnectionHelpers {
 
 abstract class QueriableConnection {
 /**
-   * Executes the [sql] query, returning a [Future]<[Results]> that completes 
+   * Executes the [sql] query, returning a [Future]<[Results]> that completes
    * when the results start to become available.
    */
   Future<Results> query(String sql);


### PR DESCRIPTION
Resolves #26.

Most of the changes here are `dartfmt` business. The fix is just one line setting `TCP_NODELAY` on sockets to `true`. 

I also added bench test for `select` queries.
